### PR TITLE
Update KDE SDK to 6.6

### DIFF
--- a/com.obsproject.Studio.Plugin.MoveTransition.yaml
+++ b/com.obsproject.Studio.Plugin.MoveTransition.yaml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.MoveTransition
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//6.5
+sdk: org.kde.Sdk//6.6
 build-extension: true
 separate-locales: false
 appstream-compose: false

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
     "skip-icons-check": true,
-    "only-arches": ["x86_64"],
-    "automerge-flathubbot-prs": true
+    "only-arches": ["x86_64"]
   }


### PR DESCRIPTION
The latest version of OBS broke plugins, so a rebuild with the latest KDE SDK is needed.